### PR TITLE
Remove __next__() from lazymap and lazyfilter

### DIFF
--- a/functionali/higher_order_functions.py
+++ b/functionali/higher_order_functions.py
@@ -38,9 +38,6 @@ class lazymap:
     def __iter__(self) -> Generator:
         return (self.fn(*i) for i in zip(*self.iterables))
 
-    def __next__(res):
-        return next(res)
-
     def __repr__(self): # pragma: no cover
         return str(tuple(self))
 
@@ -91,9 +88,6 @@ class lazyfilter:
 
     def __iter__(self) -> Generator:
         return (i for i in self.iterable if self.fn(i))
-
-    def __next__(res):
-        return next(res)
 
     def __repr__(self): # pragma: no cover
         return str(tuple(self))


### PR DESCRIPTION
They're not needed, and with the way they're implemented, they'll cause infinite recursion.